### PR TITLE
The old def still applies

### DIFF
--- a/draft-jens-7050-secure-channel.md
+++ b/draft-jens-7050-secure-channel.md
@@ -1,5 +1,5 @@
 ---
-title: "Redefining Secure Channel for ipv4only.arpa IPv6 Prefix Discovery"
+title: "Secure Channels for ipv4only.arpa IPv6 Prefix Discovery"
 abbrev: "7050-secure-channel"
 category: std
 updates: "7050"


### PR DESCRIPTION
The examples may not be all needed, but the def in 2.2 of 7050 is still OK